### PR TITLE
Prevent .pot and .po from being cleaned

### DIFF
--- a/Gettext_helpers.cmake
+++ b/Gettext_helpers.cmake
@@ -97,8 +97,8 @@ function(configure_gettext)
                 "--output=${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
     endif()
-    add_custom_command(
-        OUTPUT "${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
+    # should use add_custom_target so .pot doesn't get cleaned
+    add_custom_target(${TARGET_NAME}_gen_pot
         COMMAND "${GETTEXT_XGETTEXT_COMMAND}" ${GETTEXT_XGETTEXT_ARGS}
             ${GETTEXT_SOURCES}
             "--output=${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
@@ -125,13 +125,13 @@ function(configure_gettext)
                     "--locale=${lang}"
                 WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
         endif()
-        add_custom_command(
-            OUTPUT "${GETTEXT_POFILE_DESTINATION}/${lang}/${GETTEXT_DOMAIN}.po"
+        # should use add_custom_target so .po doesn't get cleaned
+        add_custom_target(${TARGET_NAME}_gen_po_${lang}
             COMMAND "${GETTEXT_MSGMERGE_COMMAND}" ${GETTEXT_MSGMERGE_ARGS}
                 "${GETTEXT_POFILE_DESTINATION}/${lang}/${GETTEXT_DOMAIN}.po"
                 "${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
                 "--output-file=${GETTEXT_POFILE_DESTINATION}/${lang}/${GETTEXT_DOMAIN}.po"
-            DEPENDS "${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
+            DEPENDS ${TARGET_NAME}_gen_pot
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             COMMENT "Updating the ${lang} .po file from the .pot file")
 


### PR DESCRIPTION
When using `add_custom_command` cmake automatically adds the files to the clean target. as `.pot` and `.po` files should not be deleted, these have been changed to `add_custom_target`.